### PR TITLE
Changes for metadata

### DIFF
--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -208,7 +208,7 @@ AverageCalibrationError:
   display_name: Average Calibration Error
   description: |
     Average calibration error in visual degree.
-  type: number
+  type: array of arrays
   unit: degree
 B0FieldIdentifier:
   name: B0FieldIdentifier
@@ -371,23 +371,12 @@ BrainLocation:
     which can also tie up with laminar fMRI.
   type: string
 CalibrationCount:
-  name: CalibrationType
-  display_name: Calibration Type
+  name: CalibrationCount
+  display_name: Calibration Count
   description: |
     Provide here the number of calibration performed per run.
   type: number
   minimum: 0
-CalibrationList:
-  name: CalibrationList
-  display_name: Calibration List
-  description: |
-    List of lists including information for each calibration.
-    This list includes the calibration type, recorded eye,
-    maximal calibration error, average calibration error,
-    and time relative to the first event of the event file.
-  type: array
-  items:
-    type: array
 CalibrationPosition:
   name: CalibrationPosition
   display_name: Calibration Position
@@ -2086,7 +2075,7 @@ MaximalCalibrationError:
   display_name: Maximal Calibration Error
   description: |
     Maximal calibration error in degree.
-  type: number
+  type: array of arrays
   unit: degree
 MeasurementToolMetadata:
   name: MeasurementToolMetadata

--- a/src/schema/rules/sidecars/eyetrack.yaml
+++ b/src/schema/rules/sidecars/eyetrack.yaml
@@ -31,7 +31,6 @@ EyeTrackingRecommended:
   fields:
     AverageCalibrationError: recommended
     CalibrationCount: recommended
-    CalibrationList: recommended
     CalibrationPosition: recommended
     CalibrationType: recommended
     CalibrationUnit: recommended


### PR DESCRIPTION
- change DataType from number to array of arrays for AverageCalibrationError and MaximalCalibrationError
- delete CalibrationList from metadata.yaml and eyetrack.yaml as it only contains dublicates of other metadata and thus not needed
- fix typo in metadata.yaml: CalibrationCount was wrongly named "CalibrationType" so CalibrationType was listed twic